### PR TITLE
updated MongoDB_Koans about_groups.rb for new group AP

### DIFF
--- a/koans/about_groups.rb
+++ b/koans/about_groups.rb
@@ -46,35 +46,39 @@ class AboutGroups < EdgeCase::Koan
     assert_equal __, @addresses.distinct('use.commercial').count, "Count distinct nested fields wrong"
     assert_equal [80, 40].sort, @addresses.distinct('use.commercial'), "Return distinct nested fields wrong"
   end
-
+  
   def test_simple_group
-    assert_equal __, @zips.group([:city], {}, {}, 'function() {}', true), "Group by one field"
+    assert_equal __, @zips.group({:key=>:city, :initial=>{}, :reduce=>'function() {}'}), "Group by one field"
   end
   
   def test_simple_aggregation
     assert_equal [{"city"=>"chicago", 'zsum' => 3300.0}, {"city"=>"decatur", 'zsum' => 0}], 
-      @zips.group([:city], {}, { 'zsum' => 0 }, 'function(doc,out) { out.zsum += doc.population; }', true), "Group by one field"
-    #The fourth parameter doesn't look like Ruby.  Why?  It's a string containing a JavaScript function.
+      @zips.group({:key=>:city, :initial=>{'zsum' => 0}, :reduce=>'function(doc, out) { out.zsum += doc.population; }'}), "Group by one field"
+    #The :reduce parameter doesn't look like Ruby.  Why?  It's a string containing a JavaScript function.
   end
   
   def test_aggregation_two_results
     assert_equal [{"city"=>__, 'zsum' => 3300.0, 'zstr' => 'ILILIL'}, {"city"=>"decatur", 'zsum' => 3006.0, 'zstr' => 'ILILIL'}], 
-      @zips.group([:city], {}, { 'zsum' => 0, 'zstr' => '' }, 'function(doc,out) { out.zsum += doc.population; out.zstr += doc.state; }', true), 
+      @zips.group({:key=>:city, :initial=>{'zsum' => 0, 'zstr' => ''}, :reduce=>'function(doc, out) { out.zsum += doc.population; out.zstr += doc.state}'}), 
       "Group by one field, two aggregate fields"
   end
   
   def test_aggregation_with_finalize
     assert_equal [{"city"=>"chicago", "avg_pop"=>1100.0, "zsum"=>3300.0, "zc"=>3.0}, 
                   {"city"=>"springfield", "avg_pop"=>1002.0, "zsum"=>3006.0, "zc"=>3.0}], 
-          @zips.group([:city], {}, { 'zsum' => 0, 'zc' => 0, 'avg_pop' => 0 }, 
-                     'function(doc,out) { out.zsum += doc.population; out.zc += 1; }',  
-                     'function(out){ out.avg_pop = out.zsum / out.zc}'), 
+          @zips.group({ :key => :city,
+                        :initial => { 'zsum' => 0, 'zc' => 0, 'avg_pop' => 0 },
+                        :reduce => 'function(doc, out) { out.zsum += doc.population; out.zc += 1; }',
+                        :finalize => 'function(out) { out.avg_pop = out.zsum / out.zc; }' }),  
           "Group by one field with finalize"
   end
 
   def test_aggregation_with_condition
     assert_equal [{"city"=>"chicago", 'zsum' => 3000.0}], 
-          @zips.group([:city], {"city"=>"chicago"}, { 'zsum' => 0 }, 'function(doc,out) { out.zsum += doc.population; }', true), 
+          @zips.group({ :key => :city, 
+                        :cond => {"city"=>"chicago"},
+                        :initial => { 'zsum' => 0 },
+                        :reduce => 'function(doc,out) { out.zsum += doc.population; }' }),
           "Group by one field with condition"
   end  
   #In his blog, Kyle Banker said "group() is rather a beast".  Do you agree?


### PR DESCRIPTION
Hi,

I updated about_groups for the newer group API in version 1.3.0 of the Ruby driver for MongoDB. Collections.group() now takes a hash of parameters. Using the older parameter list still works, but gives a warning: "Collection#group no longer take a list of parameters. This usage is deprecated."

See http://api.mongodb.org/ruby/current/Mongo/Collection.html#group-instance_method

Thanks, the koans were fun and made learning the API quick and easy!

-Chris
